### PR TITLE
Update the v2 API info with a new disclaimer, new info on the project…

### DIFF
--- a/docs/api-changes.md
+++ b/docs/api-changes.md
@@ -25,9 +25,9 @@ Retrieve an individual workflow by its unique ID.
 Retrieve the jobs of an individual workflow by its unique ID. Note that for now we're returning all jobs, but we reserve the right to paginate them in the future. The shape of the pagination will not change, but the default number of jobs may be reduced.
 
 ### GET /project/:project_slug
-Retrieve an individual project by its unique ID.
+Retrieve an individual project by its unique slug.
 
-## COMING SOON
+## COMING SOON  
 
 ### POST /project/:project_slug/pipeline
 Trigger a new pipeline run on a project. This endpoint will also soon have the ability to [pass parameters available during configuration processing](pipeline-parameters.md) as well as the ablity to trigger a particular branch and/or a particular workflow in your configuration.

--- a/docs/api-changes.md
+++ b/docs/api-changes.md
@@ -1,9 +1,22 @@
 
-# API changes compared to version 1.1
+# What's new in API v2?
 
-Use of the below endpoints is similar to use of the 1.1 endpoints in terms of authentication. Please refer to the main CirlceCI documentation for information on authenticating with a token.
+## BEFORE YOU START: IMPORTANT DISCLAIMER
+The CircleCI v2 API is currently in Preview release. You may use it at will, but this evaluation product is not yet fully supported or considered generally available.
 
-## NEW ENDPOINTS IN PREVIEW RELEASE
+Use of the v2 API as long as this notice is in the master branch (current as of May 2019) is done at your own risk and is governed by CircleCI’s Terms of Service.
+
+PREVIEWS ARE PROVIDED "AS-IS," "WITH ALL FAULTS," AND "AS AVAILABLE," AND ARE EXCLUDED FROM THE SERVICE LEVEL AGREEMENTS AND LIMITED WARRANTY. Previews may not be covered by customer support. Previews may be subject to reduced or different security, compliance and privacy commitments, as further explained in the Terms of Service, Privacy Policy and any additional notices provided with the Preview. We may change or discontinue Previews at any time without notice. We also may choose not to release a Preview into "General Availability."
+
+## NOTE ON AUTHENTICATION
+Use of the below endpoints is similar to use of the version 1.1 endpoints in terms of authentication. Please refer to the main CirlceCI API documentation for information on authenticating with a token.
+
+##  NEW: THE `project_slug` as a string
+The CircleCI v2 API is backwards compatible with previous API versions in the way it identifies your projects using repository name. For instance, if you want to pull information from CircleCI about the GitHub repository <https://github.com/CircleCI-Public/circleci-cli> you can refer to that in the CircleCI API as `gh/CircleCI-Public/circleci-cli`, which is a "triplet" of the project type, the name of your "organization", and the name of the repository. For the project type you can use `github` or `bitbucket` as well as the shorter forms `gh` or `bb`, which are now supported in API v2). The organization is your username or organization name in your version control system.
+
+With API v2 we are introducing a string representation of the triplet called the `project_slug`, takes the form: `<project_type>/<org_name>/<repo_name>`. The `project_slug` is included in the payload when pulling information about a project as well as when looking up a pipeline or workflow by ID. The `project_slug` can then be used to get information about the project. It's possible in the future we could change the shape of a `project_slug`, but in all cases it would be usable as a human-readable identifier for a given project.
+
+## NEW ENDPOINTS AVAILABLE FOR PREVIEW USE.
 
 ### GET /workflow/:id
 Retrieve an individual workflow by its unique ID.
@@ -11,13 +24,12 @@ Retrieve an individual workflow by its unique ID.
 ### GET /workflow/:id/jobs
 Retrieve the jobs of an individual workflow by its unique ID. Note that for now we're returning all jobs, but we reserve the right to paginate them in the future. The shape of the pagination will not change, but the default number of jobs may be reduced.
 
+### GET /project/:project_slug
+Retrieve an individual project by its unique ID.
 
 ## COMING SOON
 
-### GET /project/:id
-Retrieve an individual project by its unique ID.
-
-### POST /project/:vcs-type/:username/:project/pipeline
+### POST /project/:project_slug/pipeline
 Trigger a new pipeline run on a project. This endpoint will also soon have the ability to [pass parameters available during configuration processing](pipeline-parameters.md) as well as the ablity to trigger a particular branch and/or a particular workflow in your configuration.
 
 ### GET /pipeline/:id


### PR DESCRIPTION
…_slug, and move GET project to the released set of endpoints