### PR TITLE
Use code generation friendly attribute names

### DIFF
--- a/specs/v2-sketch.yaml
+++ b/specs/v2-sketch.yaml
@@ -303,7 +303,7 @@ components:
           additionalProperties:
             type: object
             required:
-              - authorized?
+              - is_authorized
               - domain
               - external_id
               - id
@@ -326,7 +326,7 @@ components:
               name:
                 type: string
                 example: "User Name"
-              user?:
+              is_user:
                 type: boolean
               domain:
                 type: string
@@ -334,7 +334,7 @@ components:
               type:
                 type: string
                 example: "github"
-              authorized?:
+              is_authorized:
                 type: boolean
               provider_id:
                 type: string


### PR DESCRIPTION
Swagger-codegen embeds attribute names as they are, we need to avoid
characters that aren't commonly support in identifiers.