### PR TITLE
Scheduled pipelines improvements

### DIFF
--- a/docs/scheduled-pipelines.md
+++ b/docs/scheduled-pipelines.md
@@ -20,25 +20,25 @@ If your project has no scheduled workflows and would like to try out scheduled p
 - Have your CCI token ready or create a new one following [these steps](https://circleci.com/docs/2.0/managing-api-tokens/)
 - Create a new schedule using the new Pipelines Schedule API, for example:
 
-```
-curl --location --request POST 'https://circleci.com/api/v2/project/<project-slug>/schedule' \
---header 'circle-token: <your-cci-token>' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "name": "my schedule name",
-    "description": "some description",
-    "attribution-actor": "system",
-    "parameters": {
-      "branch": "main"
-      <additional pipeline parameters can be added here>
-    },
-    "timetable": {
-        "per-hour": 3,
-        "hours-of-day": [1,15],
-        "days-of-week": ["MON", "WED"]
-    }
-}'
-```
+  ```
+  curl --location --request POST 'https://circleci.com/api/v2/project/<project-slug>/schedule' \
+  --header 'circle-token: <your-cci-token>' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+      "name": "my schedule name",
+      "description": "some description",
+      "attribution-actor": "system",
+      "parameters": {
+        "branch": "main"
+        <additional pipeline parameters can be added here>
+      },
+      "timetable": {
+          "per-hour": 3,
+          "hours-of-day": [1,15],
+          "days-of-week": ["MON", "WED"]
+      }
+  }'
+  ```
 
 - Check out the `schedule` section under the [open-api docs](https://circleci.com/docs/api/v2/) for additional information
 
@@ -58,69 +58,69 @@ To migrate from scheduled workflows to scheduled pipelines, one can follow the s
 - Find the scheduled trigger in your project's .circleci/config.yml
     - For example, it might look like this one:
 
-```
-daily-run-workflow:
-  triggers:
-    - schedule:
-        # Every day, 0421Z.
-        cron: "21 4 * * *"
-        filters:
-          branches:
-            only:
-              - main
-  jobs:
-    - test
-    - build
-```
+      ```
+      daily-run-workflow:
+        triggers:
+          - schedule:
+              # Every day, 0421Z.
+              cron: "21 4 * * *"
+              filters:
+                branches:
+                  only:
+                    - main
+        jobs:
+          - test
+          - build
+      ```
 
 - Interpret the frequency your trigger needs to run from the cron expression
 - Use the same step from `Starting from scratch` section above to create the schedule via the API
 - In the circleci config file, remove the `triggers` section so that it looks like a normal workflow
 
-```
-daily-run-workflow:
-  jobs:
-    - test
-    - build
-```
+  ```
+  daily-run-workflow:
+    jobs:
+      - test
+      - build
+  ```
 
 - Add workflows filtering. As scheduled pipeline is essentially a triggered pipeline, it will run every workflow in the config.
     - One way to implement workflows filtering is by using the pipeline values, for example:
 
-```
-daily-run-workflow:
-  when:
-    and:
-      - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-      - equal: [ "my schedule name", << pipeline.schedule.name >> ]
-  jobs:
-    - test
-    - build
-```
+      ```
+      daily-run-workflow:
+        when:
+          and:
+            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+            - equal: [ "my schedule name", << pipeline.schedule.name >> ]
+        jobs:
+          - test
+          - build
+      ```
 
 - Please note that in the above example, the second `equal` under `when` is not strictly necessary. The `pipeline.schedule.name` is an available pipeline value when the pipeline is triggered by a schedule.
 
 
 - Add workflows filtering for workflows that should NOT run when a schedule triggers:
 
-```
-daily-run-workflow:
-  when:
-    and:
-      - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-      - equal: [ "my schedule name", << pipeline.schedule.name >> ]
-  jobs:
-    - test
-    - build
+  ```
+  daily-run-workflow:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "my schedule name", << pipeline.schedule.name >> ]
+    jobs:
+      - test
+      - build
 
-other-workflow:
-  when:
-    not:
-      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-  jobs:
-   - build
-   - deploy
-```
+  other-workflow:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+     - build
+     - deploy
+  ```
 
 ## Scheduled pipeline FAQs
 

--- a/docs/scheduled-pipelines.md
+++ b/docs/scheduled-pipelines.md
@@ -10,7 +10,7 @@ Since the scheduled run is based on pipelines, scheduled pipelines have all the 
 
 CircleCI has APIs that allows users to create, view, edit, and delete Scheduled Pipelines.
 
-**Note**: *At this time, the UI for Scheduled Pipelines is not available. It will become available soon.
+**Note**: *At this time, the UI for Scheduled Pipelines is not available. It will become available soon.*
 
 ## Getting started with scheduled pipelines in CircleCI
 

--- a/docs/scheduled-pipelines.md
+++ b/docs/scheduled-pipelines.md
@@ -93,6 +93,7 @@ To migrate from scheduled workflows to scheduled pipelines, one can follow the s
           and:
             - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
             - equal: [ "my schedule name", << pipeline.schedule.name >> ]
+            - equal: [ "main", << pipeline.git.branch >> ]
         jobs:
           - test
           - build
@@ -109,14 +110,17 @@ To migrate from scheduled workflows to scheduled pipelines, one can follow the s
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "my schedule name", << pipeline.schedule.name >> ]
+        - equal: [ "main", << pipeline.git.branch >> ]
     jobs:
       - test
       - build
 
   other-workflow:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "main", << pipeline.git.branch >> ]
     jobs:
      - build
      - deploy


### PR DESCRIPTION
This PR fixes a few small things:

* A Markdown syntax omission
* Indent the code blocks so they render at the same indent depth as the list items in which they appear

It also improves the conversion examples by also including the branch filtering criteria, converted to workflow filtering syntax.

Previously the converted examples did not include workflow filtering for the branch filtering present in the previous trigger syntax:

```yaml
      daily-run-workflow:
        triggers:
          - schedule:
              # Every day, 0421Z.
              cron: "21 4 * * *"
              filters:      # <--
                branches:   # <--
                  only:     # <--
                    - main  # <-- These parts
```

Reviewers please pay special attention to the last example, because I'm not 100% sure if this is supported filtering syntax:

```yaml
when:
  and:
    - not:
        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
    - equal: [ "main", << pipeline.git.branch >> ]
```

If I have missed the detailed documentation on the [`when` and `unless` clauses](https://circleci.com/docs/2.0/pipeline-variables/#conditional-workflows), please point me to them.

Edit: Completeness and grammar.